### PR TITLE
Make build process depend on environment

### DIFF
--- a/config/development.js
+++ b/config/development.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const webpack = require('webpack');
+const path = require('path');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+//
+// Output directory and environment.
+//
+
+exports.init = (dirname) => {
+  const env = 'development';
+  const LANG = process.env.LANG || 'en-US';
+  const dist = path.join(dirname, 'public', 'dist')
+
+  return [
+  {
+    name: 'JS',
+    devtool: 'source-map',
+    entry: path.join(dirname, 'src', 'app.js'),
+    output: {
+      filename: path.join(dist, 'build', 'bundle.js')
+    },
+    plugins: [
+      new webpack.optimize.DedupePlugin(),
+      new webpack.DefinePlugin({
+        'process.env': {
+          NODE_ENV: JSON.stringify(env)
+        }
+      }),
+      new webpack.ProvidePlugin({
+          "react": "React",
+      }),
+      new ExtractTextPlugin(path.join(dist, 'app.css'))
+    ],
+
+    module: {
+      loaders: [{
+          test: /\.jsx?$/,
+          loader: 'babel-loader',
+          exclude: [
+            /node_modules\/babel[\s\S]*/
+          ],
+          query: {
+            presets: [
+              require.resolve('babel-preset-es2015'),
+              require.resolve('babel-preset-react')
+            ]
+          }
+        }, {
+          test: /\.scss$/,
+          loader: ExtractTextPlugin.extract('style-loader', 'css-loader', 'sass-loader')
+        }
+      ]}
+    }
+  ]
+}

--- a/config/production.js
+++ b/config/production.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const webpack = require('webpack');
+const path = require('path');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+//
+// Output directory and environment.
+//
+
+exports.init = (dirname) => {
+  const env = 'development';
+  const LANG = process.env.LANG || 'en-US';
+  const dist = path.join(dirname, 'public', 'dist')
+
+  return [
+  {
+    name: 'JS',
+    entry: path.join(dirname, 'src', 'app.js'),
+    output: {
+      filename: path.join(dist, 'build', 'bundle.js')
+    },
+    plugins: [
+      new webpack.optimize.DedupePlugin(),
+      new webpack.DefinePlugin({
+        'process.env': {
+          NODE_ENV: JSON.stringify(env)
+        }
+      }),
+      new webpack.ProvidePlugin({
+          "react": "React",
+      }),
+      new ExtractTextPlugin(path.join(dist, 'app.css')),
+      new webpack.optimize.UglifyJsPlugin({
+        compress: {
+          warnings: false
+        }
+      })
+    ],
+
+    module: {
+      loaders: [{
+          test: /\.jsx?$/,
+          loader: 'babel-loader',
+          exclude: [
+            /node_modules\/babel[\s\S]*/
+          ],
+          query: {
+            presets: [
+              require.resolve('babel-preset-es2015'),
+              require.resolve('babel-preset-react')
+            ]
+          }
+        }, {
+          test: /\.scss$/,
+          loader: ExtractTextPlugin.extract('style-loader', 'css-loader', 'sass-loader')
+        }
+      ]}
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node index.js",
     "watch": "rm -rf public/dist/build/ && webpack --progress --watch",
-    "deploy": "webpack --progress && rm public/dist/build/bundle.js.map && node index.js"
+    "deploy": "webpack --progress && node index.js"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,60 +1,6 @@
 'use strict';
 
-const webpack = require('webpack');
-const path = require('path');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const path = require('path')
+const env = process.env.NODE_ENV || 'development'
 
-//
-// Output directory and environment.
-//
-const dist = path.join(__dirname, 'public', 'dist');
-const env = process.env.NODE_ENV || 'development';
-const LANG = process.env.LANG || 'en-US';
-const variables = {};
-
-module.exports = [
-{
-  name: 'JS',
-  devtool: 'source-map',
-  entry: path.join(__dirname, 'src', 'app.js'),
-  output: {
-    filename: path.join(dist, 'build', 'bundle.js')
-  },
-  plugins: [
-    new webpack.optimize.DedupePlugin(),
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify(env)
-      }
-    }),
-    new webpack.ProvidePlugin({
-        "react": "React",
-    }),
-    new ExtractTextPlugin(path.join(dist, 'app.css')),
-    new webpack.optimize.UglifyJsPlugin({
-        compress: {
-          warnings: false
-        }
-      })
-  ],
-
-  module: {
-    loaders: [{
-        test: /\.jsx?$/,
-        loader: 'babel-loader',
-        exclude: [
-          /node_modules\/babel[\s\S]*/
-        ],
-        query: {
-          presets: [
-            require.resolve('babel-preset-es2015'),
-            require.resolve('babel-preset-react')
-          ]
-        }
-      }, {
-        test: /\.scss$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader', 'sass-loader')
-      }
-    ]}
-  }
-]
+module.exports = require(path.join(__dirname, 'config', env + '.js')).init(__dirname)


### PR DESCRIPTION
As an extension of #12, we just deleted the `build.js.map` in preparation for deployment. Now, we can just not even build it and be able to deploy the app much more quickly.
